### PR TITLE
Deployment redesign: own end-to-end opencfp swarm deploy

### DIFF
--- a/.github/config/opencfp-config.yml
+++ b/.github/config/opencfp-config.yml
@@ -1,0 +1,73 @@
+application:
+  title: "Longhorn PHP Conference 2025"
+  venue_image_path: https://lh3.googleusercontent.com/LXNS9pI8_2YMeZu1q9u0HpIHnvTi7Y9cViG_UQ9Yreh3pJrZg0SR12G-D-OIHUgJDioKAajJTNxzNe0-q1yeArhsSJICMToeHoN61j8837mYzbnq4aV6OUiuxH6iVjw_zEdXrBd-bpCBzzozfxEz2op8nTMfsgGbImCA4jh2hQnt0VXwujepMxYDdaE83AGesLeg-AXSWCPUsh6ZUjAaun5MMN9nP_c4sZG6kOuFdXrHsVnGUYc3fk7DiABqQ2PSroDOg_F8dToF15_tU6XPV6iSUl9P9OUNj1TorL4VWL-gq0hrvOjvSzttCf3e-NDUYMLlPJo6GkTJgFPIAQ_ibMWw4SwFEn7ja4B7P5kxvwIVbV0u4CR-eoy-xTwynGndEzIE-3Py045mb1E8sVqBZXakp9Z3mdi1REKLLWfGjz5o1FdfFAyArBJzJC0pJyI3q23IwMtET0UbseVEzdKvHGSIAXH1NChyG7OnGdyWThg-qgwZJlceFksUE1Q49k5xFFF1Cj8Dk3cSCb58Lfp5gerXEJORNYzQ3owvgAMMzzYQcdtZyNZ6e1qPhasgiK87vRo57r94g5WUef_hOhRbWaQ2NyVD7zaG3HsgOoKEIq9U7tcxTKbnvTnQuSgZSy5W3HIqg4mKtTF8RZ-MVluR8thGOIHjosDaYls34XZCl2Xx2kjEIwWcUCVP=w1299-h975-no
+  url: https://cfp.longhornphp.com
+  email: info@longhornphp.com
+  eventurl: https://www.longhornphp.com
+  event_location: Austin, TX
+  enddate: "2025-08-02 10:00:00"
+  show_submission_count: false
+  airport: AUS
+  arrival: 2025-10-22
+  departure: 2025-10-26
+  secure_ssl: false
+  online_conference: false
+  date_format: "F jS g:i a"
+  date_timezone: "America/Chicago"
+  coc_link: https://www.longhornphp.com/code-of-conduct/
+  user_image_size: 1024
+api:
+  enabled: true
+
+cache:
+  enabled: false
+
+database:
+  host: 10.3.96.3
+  database: opencfp
+  user: app
+  password: ENV_DB_PASSWORD
+
+log:
+  level: info
+
+mail:
+  host: smtp.mailgun.org
+  port: 587
+  username: ENV_SMTP_USERNAME
+  password: ENV_SMTP_PASSWORD
+  encryption: tls
+  auth_mode: ~
+
+talk:
+  categories:
+    api: APIs (Design, Tooling, etc.)
+    database: Database
+    development: Development
+    devops: DevOps (including CI/CD)
+    framework: Framework
+    javascript: JavaScript
+    altlang: Other Languages (not PHP or JS)
+    personal: Personal Skills
+    security: Security
+    testing: Testing
+    uiux: UI/UX
+    other: Other
+  levels:
+    entry: Entry level
+    mid: Intermediate
+    advanced: Advanced
+    all: Anyone
+  types:
+    talk: Talk (50 minutes including questions)
+    tutorial: Tutorial (3 hours)
+    allday: All-Day tutorial (6-7 hours)
+
+opencfpcentral:
+  sso: off
+  clientId: ENV_OPEN_CFP_CENTRAL_CLIENT_ID
+  clientSecret: ENV_OPEN_CFP_CENTRAL_CLIENT_SECRET
+  authorizeUrl: https://www.opencfpcentral.com/oauth/authorize?
+  redirectUri: https://cfp.longhornphp.com/sso/redirect
+  resourceUri: https://www.opencfpcentral.com/api/user
+  tokenUrl: https://www.opencfpcentral.com/oauth/token

--- a/.github/workflows/vultr.yml
+++ b/.github/workflows/vultr.yml
@@ -1,30 +1,188 @@
-name: Publish Longhorn PHP Open CFP Docker Image
+name: Vultr Deploy
 on:
   push:
-    branches:
-      - conf-specific
+    branches: [conf-specific]
+  workflow_dispatch:
+
+concurrency:
+  group: vultr-deploy
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy app
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      config: ${{ steps.filter.outputs.config }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'src/**'
+              - 'web/**'
+              - 'resources/**'
+              - 'migrations/**'
+              - 'composer.json'
+              - 'composer.lock'
+              - 'package.json'
+              - 'webpack.mix.js'
+              - '.docker/**'
+              - '.github/workflows/vultr.yml'
+            config:
+              - '.github/config/opencfp-config.yml'
+
+  build:
+    name: Build & push image
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           registry: ord.vultrcr.com
           username: ${{ vars.VULTR_USERNAME }}
           password: ${{ secrets.VULTR_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
         with:
+          context: .
+          file: .docker/Dockerfile
           push: true
-          tags: ord.vultrcr.com/longhorn/cfp:latest
+          tags: |
+            ord.vultrcr.com/longhorn/cfp:latest
+            ord.vultrcr.com/longhorn/cfp:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: .docker/Dockerfile
-          context: .
+          platforms: linux/amd64
+
+  config:
+    name: Sync rendered config to host
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.config == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Render production config (substitute secrets)
+        run: |
+          cp .github/config/opencfp-config.yml opencfp-production.yml
+          sed -i 's|ENV_DB_PASSWORD|${{ secrets.OPENCFP_DB_PASSWORD }}|g' opencfp-production.yml
+          sed -i 's|ENV_SMTP_USERNAME|${{ vars.OPENCFP_SMTP_USERNAME }}|g' opencfp-production.yml
+          sed -i 's|ENV_SMTP_PASSWORD|${{ secrets.OPENCFP_SMTP_PASSWORD }}|g' opencfp-production.yml
+          sed -i 's|ENV_OPEN_CFP_CENTRAL_CLIENT_ID|${{ vars.OPENCFP_CENTRAL_CLIENT_ID }}|g' opencfp-production.yml
+          sed -i 's|ENV_OPEN_CFP_CENTRAL_CLIENT_SECRET|${{ secrets.OPENCFP_CENTRAL_CLIENT_SECRET }}|g' opencfp-production.yml
+        shell: bash
+
+      - name: Write SSH key
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_ed25519
+          echo "${{ secrets.VULTR_SSH_KEY }}" > ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.VULTR_HOST }} > ~/.ssh/known_hosts
+        shell: bash
+
+      - name: SCP rendered config to host
+        run: |
+          scp -i ~/.ssh/id_ed25519 opencfp-production.yml \
+            linuxuser@"${{ secrets.VULTR_HOST }}":~/opencfp-production.yml
+        shell: bash
+
+  deploy:
+    name: Migrate, deploy, verify
+    runs-on: ubuntu-latest
+    needs: [changes, build, config]
+    if: |
+      always() && !cancelled() && !failure() && (
+        needs.build.result == 'success' || needs.config.result == 'success'
+      )
+    steps:
+      - name: Write SSH key
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_ed25519
+          echo "${{ secrets.VULTR_SSH_KEY }}" > ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.VULTR_HOST }} > ~/.ssh/known_hosts
+        shell: bash
+
+      - name: Migrate (only if image changed)
+        if: needs.build.result == 'success'
+        env:
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          ssh -i ~/.ssh/id_ed25519 linuxuser@"${{ secrets.VULTR_HOST }}" \
+            "docker run --rm --network host \
+              -v ~/opencfp-production.yml:/srv/application/config/production.yml:ro \
+              -e CFP_ENV=production \
+              ord.vultrcr.com/longhorn/cfp:${GIT_SHA} \
+              bin/console doctrine:migrations:migrate --env=production --no-interaction"
+        shell: bash
+
+      - name: Roll service & wait for convergence
+        env:
+          GIT_SHA: ${{ github.sha }}
+          BUILD_RAN: ${{ needs.build.result == 'success' }}
+        run: |
+          ssh -i ~/.ssh/id_ed25519 linuxuser@"${{ secrets.VULTR_HOST }}" bash -s -- "${GIT_SHA}" "${BUILD_RAN}" <<'ENDSSH'
+            set -euo pipefail
+            GIT_SHA="$1"
+            BUILD_RAN="$2"
+            IMAGE="ord.vultrcr.com/longhorn/cfp:${GIT_SHA}"
+
+            if [ "$BUILD_RAN" = "true" ]; then
+              echo "==> Rolling service to ${IMAGE}"
+              docker service update \
+                --image "$IMAGE" \
+                --with-registry-auth \
+                --update-failure-action rollback \
+                longhornphp_opencfp
+            else
+              echo "==> Config-only deploy: forcing task recreation to pick up new mounted config"
+              docker service update --force longhornphp_opencfp
+            fi
+
+            echo "==> Polling Swarm UpdateStatus"
+            TIMEOUT=300
+            ELAPSED=0
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+              STATE=$(docker service inspect --format '{{.UpdateStatus.State}}' longhornphp_opencfp)
+              echo "==> UpdateStatus.State=${STATE} (elapsed ${ELAPSED}s)"
+              case "$STATE" in
+                completed) break ;;
+                rollback_completed)
+                  echo "::error::Deploy rolled back. New image failed healthcheck."
+                  docker service ps longhornphp_opencfp --no-trunc
+                  exit 1 ;;
+                paused)
+                  echo "::error::Deploy paused (manual intervention required)."
+                  exit 1 ;;
+              esac
+              sleep 5
+              ELAPSED=$((ELAPSED+5))
+            done
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "::error::convergence timeout after ${TIMEOUT}s"
+              docker service ps longhornphp_opencfp --no-trunc
+              exit 1
+            fi
+
+            if [ "$BUILD_RAN" = "true" ]; then
+              echo "==> Verifying running tasks are on ${IMAGE}"
+              RUNNING=$(docker service ps longhornphp_opencfp \
+                --filter 'desired-state=running' --format '{{.Image}}' | sort -u)
+              if ! echo "$RUNNING" | grep -qx "$IMAGE"; then
+                echo "::error::tasks not on expected SHA. Running: $RUNNING"
+                exit 1
+              fi
+            fi
+            echo "==> Deploy complete"
+          ENDSSH
+        shell: bash
+
+      - name: Verify
+        run: |
+          curl --fail --silent --show-error --max-time 30 -o /dev/null \
+            -w "HTTP %{http_code} in %{time_total}s\n" \
+            https://cfp.longhornphp.com/
+        shell: bash


### PR DESCRIPTION
## Summary

- Rewrite vultr.yml: changes filter, build (now SHA-tagged), config secret substitution + SCP, migrate via Doctrine, deploy with --update-failure-action rollback, UpdateStatus poll, HTTPS verification
- Add .github/config/opencfp-config.yml (moved from longhornphp-app, byte-identical)
- Triggers on conf-specific branch (unchanged)
- Bump dorny/paths-filter v2 -> v3 (Node 16 deprecation)

## Coordinated rollout

This PR is one of three. **Merge order:**
1. Merge longhornphp-mailcoach PR first
2. Merge this PR
3. Trigger one deploy on each to validate the new mechanism end-to-end
4. Then merge longhornphp-app PR (which removes the now-redundant OpenCFP orchestration steps)

Spec lives in longhornphp-app: `docs/superpowers/specs/2026-04-25-deployment-redesign-design.md`

## New repo secrets/vars required (set before merge)

Secrets: VULTR_HOST, VULTR_SSH_KEY, OPENCFP_DB_PASSWORD, OPENCFP_SMTP_PASSWORD, OPENCFP_CENTRAL_CLIENT_SECRET
Vars: OPENCFP_SMTP_USERNAME, OPENCFP_CENTRAL_CLIENT_ID

(Same values as longhornphp-app's existing secrets — copy across before merging.)

## Test plan

- [ ] Workflow YAML lints clean (actionlint)
- [ ] After merge, deploy run shows: changes → build → config (skipped if no config diff) → deploy → verify all green
- [ ] \`ssh linuxuser@\$VULTR_HOST 'docker service ps longhornphp_opencfp'\` shows running tasks pinned to the merged SHA (not :latest)
- [ ] \`curl -s https://cfp.longhornphp.com/\` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)